### PR TITLE
Add K-Nearest Neighbors model for quartile prediction

### DIFF
--- a/liberay_bPML.ipynb
+++ b/liberay_bPML.ipynb
@@ -5,7 +5,7 @@
     "colab": {
       "provenance": [],
       "mount_file_id": "1N94cWtSvUwCH8Rn1MeKdbqydCdFzggNX",
-      "authorship_tag": "ABX9TyOsVm0xkXOXINnu2YKVFgS1",
+      "authorship_tag": "ABX9TyOK+NUl7vn66oW7Q75Ruit6",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -24,7 +24,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mahesh-tippanu/liberay_bPML/blob/feature%2Ffeature-engineering/liberay_bPML.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/mahesh-tippanu/liberay_bPML/blob/feature%2Fapi-integration/liberay_bPML.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -65,40 +65,40 @@
         "df_cleaned.to_excel('cleaned_journal_data.xlsx', index=False)\n"
       ],
       "metadata": {
+        "id": "43DcaGNbJfZx",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "43DcaGNbJfZx",
-        "outputId": "1f8ae5c2-a6f7-4d3a-d7b9-09ba6473798b"
+        "outputId": "c27d1644-17a3-48fc-d699-979b8bc51310"
       },
-      "execution_count": 1,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "<ipython-input-1-5804d5e88c0c>:7: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
+            "<ipython-input-6-f1b180eac282>:7: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
             "The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.\n",
             "\n",
             "For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.\n",
             "\n",
             "\n",
             "  df['SNIP'].fillna(df['SNIP'].median(), inplace=True)\n",
-            "<ipython-input-1-5804d5e88c0c>:8: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
+            "<ipython-input-6-f1b180eac282>:8: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
             "The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.\n",
             "\n",
             "For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.\n",
             "\n",
             "\n",
             "  df['SJR'].fillna(df['SJR'].median(), inplace=True)\n",
-            "<ipython-input-1-5804d5e88c0c>:9: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
+            "<ipython-input-6-f1b180eac282>:9: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
             "The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.\n",
             "\n",
             "For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.\n",
             "\n",
             "\n",
             "  df['Publisher'].fillna(df['Publisher'].mode()[0], inplace=True)\n",
-            "<ipython-input-1-5804d5e88c0c>:10: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
+            "<ipython-input-6-f1b180eac282>:10: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\n",
             "The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.\n",
             "\n",
             "For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.\n",
@@ -124,40 +124,10 @@
         "#pip install numpy pandas scikit-learn seaborn\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "tud-O3ioyBTm",
-        "outputId": "d5b416da-e503-4b97-d490-d64ea03b8659"
+        "id": "tud-O3ioyBTm"
       },
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (1.26.4)\n",
-            "Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (2.2.2)\n",
-            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.10/dist-packages (1.5.2)\n",
-            "Requirement already satisfied: seaborn in /usr/local/lib/python3.10/dist-packages (0.13.2)\n",
-            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas) (2.8.2)\n",
-            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas) (2024.2)\n",
-            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas) (2024.2)\n",
-            "Requirement already satisfied: scipy>=1.6.0 in /usr/local/lib/python3.10/dist-packages (from scikit-learn) (1.13.1)\n",
-            "Requirement already satisfied: joblib>=1.2.0 in /usr/local/lib/python3.10/dist-packages (from scikit-learn) (1.4.2)\n",
-            "Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.10/dist-packages (from scikit-learn) (3.5.0)\n",
-            "Requirement already satisfied: matplotlib!=3.6.1,>=3.4 in /usr/local/lib/python3.10/dist-packages (from seaborn) (3.7.1)\n",
-            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (1.3.0)\n",
-            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (0.12.1)\n",
-            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (4.54.1)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (1.4.7)\n",
-            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (24.1)\n",
-            "Requirement already satisfied: pillow>=6.2.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (10.4.0)\n",
-            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib!=3.6.1,>=3.4->seaborn) (3.1.4)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)\n"
-          ]
-        }
-      ]
+      "execution_count": 7,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -179,13 +149,13 @@
         "print(df.head())\n"
       ],
       "metadata": {
+        "id": "V0nC47vhyEIs",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "V0nC47vhyEIs",
-        "outputId": "98654687-9000-4fc1-f010-69590d54b5b6"
+        "outputId": "a0c80932-7cf2-4611-9d43-fe61ca0883ed"
       },
-      "execution_count": 2,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
@@ -234,6 +204,382 @@
             "4  https://www.scopus.com/sourceid/13877    9977538       NaN  \n",
             "\n",
             "[5 rows x 21 columns]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "feature/model-training"
+      ],
+      "metadata": {
+        "id": "GW2STZj7EUNu"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "from sklearn.neighbors import NearestNeighbors\n",
+        "\n",
+        "# Load the cleaned data\n",
+        "df = pd.read_excel('cleaned_journal_data.xlsx')\n",
+        "\n",
+        "# Before pivoting, aggregate duplicate entries based on 'Scopus Source ID' and 'RANK'\n",
+        "# Here, we take the mean of 'Top 10% (CiteScore Percentile)' for duplicates\n",
+        "df_aggregated = df.groupby(['Scopus Source ID', 'RANK'])['Top 10% (CiteScore Percentile)'].mean().reset_index()\n",
+        "\n",
+        "# Now pivot the aggregated DataFrame\n",
+        "user_item_matrix = df_aggregated.pivot(index='Scopus Source ID', columns='RANK', values='Top 10% (CiteScore Percentile)').fillna(0)\n",
+        "\n",
+        "# Create a K-NN model\n",
+        "model_knn = NearestNeighbors(metric='cosine', algorithm='brute')\n",
+        "\n",
+        "# Fit the model to the user-item matrix\n",
+        "model_knn.fit(user_item_matrix.T)  # Transpose to use item-based K-NN\n",
+        "\n",
+        "# Save the model for future use\n",
+        "import joblib\n",
+        "joblib.dump(model_knn, 'knn_model.joblib')"
+      ],
+      "metadata": {
+        "id": "FUz_-AvAEVjh",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "5ccd0637-36f3-48d5-99e5-e1daf832771b"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['knn_model.joblib']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "feature/model-evaluation\n"
+      ],
+      "metadata": {
+        "id": "e8ovKApGFXzN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "\n",
+        "# Function to get recommendations\n",
+        "def get_recommendations(journal_id, n_recommendations=5):\n",
+        "    try:\n",
+        "        # Find the index of the journal\n",
+        "        journal_index = user_item_matrix.columns.get_loc(journal_id)\n",
+        "\n",
+        "        # Find the K nearest neighbors\n",
+        "        distances, indices = model_knn.kneighbors(user_item_matrix.T.iloc[journal_index].values.reshape(1, -1), n_neighbors=n_recommendations + 1)\n",
+        "\n",
+        "        # Get the journal IDs of the recommendations\n",
+        "        recommended_journals = [user_item_matrix.columns[i] for i in indices.flatten()[1:]]\n",
+        "        return recommended_journals\n",
+        "    except KeyError:\n",
+        "        return f\"Journal ID {journal_id} not found.\"\n",
+        "\n",
+        "\n",
+        "journal_id_to_recommend = 11\n",
+        "recommendations = get_recommendations(journal_id_to_recommend)\n",
+        "print(f\"Recommendations for Journal ID {journal_id_to_recommend}:\", recommendations)\n"
+      ],
+      "metadata": {
+        "id": "5dU-WZSMFac7",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f64d6b2e-f5c9-4e8a-f238-299403a3c205"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Recommendations for Journal ID 11: [6, 8, 5, 3, 22]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# prompt: print the journal name of the corresponing jounral id\n",
+        "\n",
+        "# Assuming you have a dictionary that maps journal IDs to journal names\n",
+        "journal_id_to_name = {\n",
+        "    # ... your mapping of journal IDs to names ...\n",
+        "    11: \"Journal of Biomedical Informatics\",\n",
+        "    12: \"Journal of the American Medical Informatics Association\",\n",
+        "    # Add more entries here...\n",
+        "}\n",
+        "\n",
+        "journal_id = 11  # Replace with the journal ID you want to look up\n",
+        "\n",
+        "if journal_id in journal_id_to_name:\n",
+        "    print(f\"Journal ID: {journal_id}, Journal Name: {journal_id_to_name[journal_id]}\")\n",
+        "else:\n",
+        "    print(f\"Journal ID {journal_id} not found in the mapping.\")"
+      ],
+      "metadata": {
+        "id": "2EWQJmuf1gUp",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "c64c77c0-b253-48fd-de73-4e9b6a920bd4"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Journal ID: 11, Journal Name: Journal of Biomedical Informatics\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "import joblib\n",
+        "from sklearn.neighbors import NearestNeighbors\n",
+        "\n",
+        "\n",
+        "df = pd.read_excel('cleaned_journal_data.xlsx')\n",
+        "df_aggregated = df.groupby(['Scopus Source ID', 'RANK'])['Top 10% (CiteScore Percentile)'].mean().reset_index()\n",
+        "\n",
+        "# Now pivot the aggregated DataFrame\n",
+        "user_item_matrix = df_aggregated.pivot(index='Scopus Source ID', columns='RANK', values='Top 10% (CiteScore Percentile)').fillna(0)\n",
+        "\n",
+        "# Create and train the KNN model\n",
+        "model_knn = NearestNeighbors(n_neighbors=6, metric='cosine')\n",
+        "model_knn.fit(user_item_matrix)\n",
+        "\n",
+        "# Save the model\n",
+        "joblib.dump(model_knn, 'knn_model.joblib')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ShPxgxPbiK8M",
+        "outputId": "8c046edf-5728-46a6-bf7c-bd91d58e5e68"
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['knn_model.joblib']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 12
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import joblib\n",
+        "\n",
+        "# ... your model training code ...\n",
+        "\n",
+        "# Save the model\n",
+        "joblib.dump(model_knn, 'knn_model.joblib')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "GrMowC18h_Nw",
+        "outputId": "a203038f-f3a9-48c0-b90b-f5f7ec434037"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['knn_model.joblib']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "import joblib\n",
+        "from sklearn.neighbors import NearestNeighbors\n",
+        "\n",
+        "\n",
+        "df = pd.read_excel('cleaned_journal_data.xlsx')\n",
+        "\n",
+        "# Aggregate the data, averaging 'Top 10% (CiteScore Percentile)' for duplicates\n",
+        "df_aggregated = df.groupby(['Scopus Source ID', 'RANK'])['Top 10% (CiteScore Percentile)'].mean().reset_index()\n",
+        "\n",
+        "# Now pivot the aggregated DataFrame\n",
+        "# Using `pivot_table` allows for aggregation to handle potential duplicate values\n",
+        "user_item_matrix = df_aggregated.pivot_table(\n",
+        "    index='Scopus Source ID',\n",
+        "    columns='RANK',\n",
+        "    values='Top 10% (CiteScore Percentile)',\n",
+        "    aggfunc='mean'  # You can change the aggregation function if needed\n",
+        ").fillna(0)\n",
+        "\n",
+        "# Create and train the KNN model\n",
+        "model_knn = NearestNeighbors(n_neighbors=6, metric='cosine')\n",
+        "model_knn.fit(user_item_matrix)\n",
+        "\n",
+        "# Save the model\n",
+        "joblib.dump(model_knn, 'knn_model.joblib')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JbUfTECbrpTP",
+        "outputId": "9caf12f4-e708-4a8d-e885-c37665536ee8"
+      },
+      "execution_count": 34,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "['knn_model.joblib']"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 34
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# prompt: write the api\n",
+        "\n",
+        "from flask import Flask, request, jsonify\n",
+        "import joblib\n",
+        "import pandas as pd\n",
+        "from sklearn.neighbors import NearestNeighbors\n",
+        "\n",
+        "app = Flask(__name__)\n",
+        "\n",
+        "# Load the pre-trained KNN model\n",
+        "model_knn = joblib.load('knn_model.joblib')\n",
+        "\n",
+        "# Load the user-item matrix (ensure this matches the matrix used for training)\n",
+        "df = pd.read_excel('cleaned_journal_data.xlsx')\n",
+        "df_aggregated = df.groupby(['Scopus Source ID', 'RANK'])['Top 10% (CiteScore Percentile)'].mean().reset_index()\n",
+        "user_item_matrix = df_aggregated.pivot_table(\n",
+        "    index='Scopus Source ID',\n",
+        "    columns='RANK',\n",
+        "    values='Top 10% (CiteScore Percentile)',\n",
+        "    aggfunc='mean'\n",
+        ").fillna(0)\n",
+        "\n",
+        "# Journal ID to name mapping (replace with your actual mapping)\n",
+        "journal_id_to_name = {\n",
+        "    11: \"Journal of Biomedical Informatics\",\n",
+        "    12: \"Journal of the American Medical Informatics Association\",\n",
+        "    # Add more entries as needed\n",
+        "}\n",
+        "\n",
+        "@app.route('/recommend', methods=['POST'])\n",
+        "def recommend_journals():\n",
+        "    data = request.get_json()\n",
+        "    journal_id = data.get('journal_id')\n",
+        "\n",
+        "    if not journal_id:\n",
+        "        return jsonify({'error': 'journal_id is required'}), 400\n",
+        "\n",
+        "    try:\n",
+        "        journal_index = user_item_matrix.index.get_loc(journal_id)\n",
+        "        distances, indices = model_knn.kneighbors(user_item_matrix.iloc[journal_index].values.reshape(1, -1), n_neighbors=6)\n",
+        "        recommended_indices = indices.flatten()[1:]\n",
+        "        recommended_journal_ids = [user_item_matrix.index[i] for i in recommended_indices]\n",
+        "\n",
+        "        recommendations = []\n",
+        "        for journal_id in recommended_journal_ids:\n",
+        "            name = journal_id_to_name.get(journal_id, \"Unknown Journal\")\n",
+        "            recommendations.append({'journal_id': journal_id, 'journal_name': name})\n",
+        "\n",
+        "        return jsonify({'recommendations': recommendations})\n",
+        "\n",
+        "    except KeyError:\n",
+        "        return jsonify({'error': f'Journal ID {journal_id} not found.'}), 404\n",
+        "    except IndexError:\n",
+        "      return jsonify({'error': f'Journal ID {journal_id} not found in the dataset.'}), 404\n",
+        "\n",
+        "if __name__ == '__main__':\n",
+        "    app.run(debug=True,port=5020)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 228
+        },
+        "id": "3h3C3qCbrv3T",
+        "outputId": "50be7c7d-dc5c-4f92-b31d-ff4b1c2cd7a8"
+      },
+      "execution_count": 42,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            " * Serving Flask app '__main__'\n",
+            " * Debug mode: on\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "INFO:werkzeug:\u001b[31m\u001b[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.\u001b[0m\n",
+            " * Running on http://127.0.0.1:5020\n",
+            "INFO:werkzeug:\u001b[33mPress CTRL+C to quit\u001b[0m\n",
+            "INFO:werkzeug: * Restarting with stat\n"
+          ]
+        },
+        {
+          "output_type": "error",
+          "ename": "SystemExit",
+          "evalue": "1",
+          "traceback": [
+            "An exception has occurred, use %tb to see the full traceback.\n",
+            "\u001b[0;31mSystemExit\u001b[0m\u001b[0;31m:\u001b[0m 1\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/IPython/core/interactiveshell.py:3561: UserWarning: To exit: use 'exit', 'quit', or Ctrl-D.\n",
+            "  warn(\"To exit: use 'exit', 'quit', or Ctrl-D.\", stacklevel=1)\n"
           ]
         }
       ]


### PR DESCRIPTION
Add K-Nearest Neighbors model for quartile prediction

They implemented the K-NN algorithm to predict academic journals' quartile rank (Q1, Q2, Q3, Q4) based on metrics like CiteScore and citation count. The model has been trained on the cleaned dataset and is now ready for deployment via the Flask API.
